### PR TITLE
Add Logging to /names for IP debugging

### DIFF
--- a/src/names/get_names.py
+++ b/src/names/get_names.py
@@ -1,12 +1,16 @@
 from ..cw.ContentWarningNames import ContentWarningNames
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 get_names_router = APIRouter()
 
 
 @get_names_router.get("/names")
-def get_all_cw_names():
+def get_all_cw_names(request: Request):
     """
     Returns an ordered list of CW names/types
     """
+    
+    # TODO: remove, this is just for testing purposes
+    print(request.headers)
+
     return {"cws": [name.value for name in ContentWarningNames]}


### PR DESCRIPTION
# What?
There is no new feature added here. I am simply adding temporary logging to an endpoint so I can view in the AWS console which headers cloudflare passes us. Since I cannot debug issues easily with CF unless we update our endpoint there, I'm making this small change, which I will later remove.