### PR TITLE
/search: Don't Sort on Default

### DIFF
--- a/src/movies/search.py
+++ b/src/movies/search.py
@@ -66,7 +66,7 @@ def search(
     # sort if necessary
     if sort not in [
         MovieReducedFields.default_descending,
-        MovieReducedFields.default_descending,
+        MovieReducedFields.default_ascending,
     ]:
         movies_list = sorted(
             movies_list,


### PR DESCRIPTION
# What?
Fixed bug that was attempting to sort results on default settings (results in HTTP 500).

# Testing
Postman

# Reviewers
@nategaulke @jeffreydivi 