### PR TITLE
Swagger Docstrings for all Endpoints

### DIFF
--- a/src/cw/edit_cw.py
+++ b/src/cw/edit_cw.py
@@ -29,6 +29,10 @@ async def edit_cw(
     cw_id: str = None,
     root: ContentWarningPosting = None,
 ) -> ContentWarningReduced:
+    """
+    Edits specified CW, returns ContentWarningReduced
+    """
+
     if cw_id is None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="No CW ID given.")
 

--- a/src/cw/get_cw.py
+++ b/src/cw/get_cw.py
@@ -7,7 +7,10 @@ get_cw_router = APIRouter()
 
 
 @get_cw_router.get("/cw/{id}")
-def get_cw(id: str) -> Union[ContentWarningReduced, None]:
+def get_cw(id: str):
+    """
+    Given CW ID, returns ContentWarningReduced
+    """
     warning = ContentWarningTable.get_warning(id)
 
     if warning is None:

--- a/src/cw/has_voted.py
+++ b/src/cw/has_voted.py
@@ -15,6 +15,10 @@ class VotedOptions(str, Enum):
 
 @has_voted_router.get("/cw/{id}/has-voted")
 def has_voted(id: str, request: Request):
+    """
+    Given CW ID, has caller IP address upvoted, downvoted, or not interacted?
+    Returns VotedOptions enum.
+    """
     hashed_ip_address = Sha256.hash(IPAddress.get_ip_address(request))
     vote_option: VotedOptions = VotedOptions.nothing
 

--- a/src/cw/vote.py
+++ b/src/cw/vote.py
@@ -48,9 +48,15 @@ def __vote_helper(cw_id: str, ip_address: str, upvote: bool = True) -> str:
 
 @vote_router.get("/cw/{id}/upvote")
 def upvote(id: str, request: Request) -> str:
+    """
+    Attempts to upvote CW, returns success or failure strings
+    """
     return __vote_helper(id, IPAddress.get_ip_address(request), upvote=True)
 
 
 @vote_router.get("/cw/{id}/downvote")
 def downvote(id: str, request: Request) -> str:
+    """
+    Attempts to downvote CW, returns success or failure strings
+    """
     return __vote_helper(id, IPAddress.get_ip_address(request), upvote=False)

--- a/src/movies/get_movie.py
+++ b/src/movies/get_movie.py
@@ -7,6 +7,9 @@ get_movie_router = APIRouter()
 
 
 @get_movie_router.get("/movie/{id}")
-def get_cw(id: int) -> List[ContentWarningReduced]:
+def get_movie(id: int) -> List[ContentWarningReduced]:
+    """
+    Given TMDB ID, returns MovieFull object, or None if not found
+    """
     movie = MovieFull.create(id)
     return movie if movie is None else movie.jsonify()

--- a/src/movies/post_cw.py
+++ b/src/movies/post_cw.py
@@ -26,7 +26,11 @@ async def post_cw(
     request: Request,
     token: Optional[str] = Depends(oauth2_scheme),
     root: ContentWarningPosting = None,
-) -> Dict[ContentWarningReduced, Dict[str, str]]:
+):
+    """
+    Post CW obj to databases (user, CW, movies), and return list of ContentWarningReduced
+    """
+
     if root is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/movies/search.py
+++ b/src/movies/search.py
@@ -39,6 +39,10 @@ def search(
     sort: MovieReducedFields = MovieReducedFields.default_ascending,
     genre: Genre = Genre.Disregard,
 ):
+    """
+    Return list of MovieReduced objects
+    """
+
     # retrieve trending movies if query string is null or empty
     response = (
         get_trending_movies()

--- a/src/users/delete_user_op.py
+++ b/src/users/delete_user_op.py
@@ -17,6 +17,9 @@ async def delete_user_op(
     token: Optional[str] = Depends(oauth2_scheme),
     deletion_code: str = None,
 ) -> str:
+    """
+    Deletes user from tables (doesn't delete CW objects), returns string of operation status
+    """
     if deletion_code is None or len(deletion_code) == 0:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="No deletion code provided."

--- a/src/users/delete_user_request.py
+++ b/src/users/delete_user_request.py
@@ -17,6 +17,10 @@ async def delete_user_request(
     request: Request,
     token: Optional[str] = Depends(oauth2_scheme),
 ) -> str:
+    """
+    Sends delete request email, returns string of operation status
+    """
+
     json_response = {"response": "Check your email for a deletion reset code."}
 
     email = JWT.get_email(token)

--- a/src/users/edit_user.py
+++ b/src/users/edit_user.py
@@ -21,6 +21,9 @@ async def edit_user(
     token: Optional[str] = Depends(oauth2_scheme),
     incoming_user: UserReduced = None,
 ) -> str:
+    """
+    Edits user info, returning string of operation status
+    """
     if incoming_user is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/users/get_user.py
+++ b/src/users/get_user.py
@@ -16,6 +16,9 @@ async def get_user(
     request: Request,
     token: Optional[str] = Depends(oauth2_scheme),
 ) -> UserExported:
+    """
+    Returns information on a given user as UserExported object
+    """
     email = JWT.get_email(token)
 
     # before obtaining user, prune any dead CWs

--- a/src/users/login_user.py
+++ b/src/users/login_user.py
@@ -9,6 +9,9 @@ login_user_router = APIRouter()
 
 @login_user_router.post("/auth/login")
 def login_user(incoming_user: UserReduced):
+    """
+    Logs in a user, returns JWT string
+    """
     user = UserTable.get_user(incoming_user.email)
 
     if user is None:

--- a/src/users/password_reset_op.py
+++ b/src/users/password_reset_op.py
@@ -12,6 +12,10 @@ password_reset_op_router = APIRouter()
 
 @password_reset_op_router.post("/user/password-reset-op")
 def password_reset_op(user_reset: UserPasswordReset) -> str:
+    """
+    Performs password reset operation, returning string of operation status
+    """
+
     uv_obj = UserVerificationTable.get_user_verification_obj(user_reset.email)
     if uv_obj is None:
         raise HTTPException(

--- a/src/users/password_reset_request.py
+++ b/src/users/password_reset_request.py
@@ -9,6 +9,9 @@ password_reset_request_router = APIRouter()
 
 @password_reset_request_router.get("/user/password-reset-request")
 def password_reset_request(email: str) -> str:
+    """
+    Sends password reset email, returns string of operation status
+    """
     json_response = {"response": "Check your email for a password reset code."}
 
     # create a new verification code for the user

--- a/src/users/register_user.py
+++ b/src/users/register_user.py
@@ -10,6 +10,10 @@ register_user_router = APIRouter()
 
 @register_user_router.post("/user/register")
 def register_user(user: UserReduced):
+    """
+    Registers a user, returning a string specifying to check one's email
+    """
+
     # check if user already exists
     if UserTable.get_user(user.email) is not None:
         raise HTTPException(

--- a/src/users/verify_user.py
+++ b/src/users/verify_user.py
@@ -28,7 +28,8 @@ def complete_new_email_verif_process(user: User) -> None:
 @verify_user_router.post("/user/verify")
 def verify_user(uv_obj: UserVerificationReduced):
     """
-    With input of specified user email and verification code, performs user verification
+    With input of specified user email and verification code, performs user verification.
+    Returns result string specifying operation status.
     """
     user_verification_obj = UserVerificationTable.get_user_verification_obj(
         uv_obj.email


### PR DESCRIPTION
# What?
Added docs for all endpoints. I was hoping to include FastAPI `response_model`s to display actual objects we're returning, but this performs validation and can introduce breaking changes. This suffices for now.

# How?
Docs via python docstrings.

# Testing
Deployed on test stage and opened `/docs` to verify documentation was updated.

# Links
closes #19 