### PR TITLE
Fix Pytests

### DIFF
--- a/src/movies/test_movies.py
+++ b/src/movies/test_movies.py
@@ -9,8 +9,11 @@ from ..main import app
 from ..cw import ContentWarning
 from . import MovieReduced, MovieFull
 from ..test_main import get_fake_session
+from requests import get
 
 client = TestClient(app)
+
+IP_ADDRESS = get("https://ipapi.co/ip/").text
 
 
 def test_get_movie():


### PR DESCRIPTION
# What?
Fixed failing pytests

# How?
Tests were failing due to numerous issues: IPs not being set correctly due to no header w/FastAPI TestClient, pytests being outdated w/new API, `response` not being found in JSON because `json()` method seems to parse that away, etc. Please see edits in source code.

# Testing
`pytest` 100% passing

# Links
closes #69 