### PR TITLE
Search enhancements

### DIFF
--- a/src/movies/search.py
+++ b/src/movies/search.py
@@ -33,13 +33,15 @@ def get_trending_movies(genre=Genre.Disregard, mm_page=1) -> requests.Response:
 
     if genre == Genre.Disregard:
         if mm_page == 1:
-            return TMDB.hit_api("trending/movie/day")
+            return TMDB.hit_api("trending/movie/day").json()
         else:
             return {"results": []}
     else:
         gid = GENRE_MAP[genre]
 
-        return search_movie(query="", mm_page=mm_page, endpoint="discover/movie", genre_id=gid)
+        return search_movie(
+            query="", mm_page=mm_page, endpoint="discover/movie", genre_id=gid
+        )
 
 
 def search_movie(
@@ -97,7 +99,7 @@ def search(
     movies_list: List[MovieReduced] = []
 
     # return empty list if no results
-    if "results" not in json_map.keys():
+    if len(json_map.get("results", [])) <= 0:
         # logging
         print("No results for TMDB search.")
         print(json_map)

--- a/src/movies/test_movies.py
+++ b/src/movies/test_movies.py
@@ -233,7 +233,7 @@ def test_get_search_p():
     """
 
     # Get if p set.
-    data = client.get("/search?q=Avatar&p=2")
+    data = client.get("/search?q=Avata&p=2")  # 61 results.
     assert data.status_code == 200, "GET /search?p: Invalid response from server."
 
     data_json = data.json()


### PR DESCRIPTION
# What?
- All genre pages will now return movies, guaranteed, via the TMDB Discovery endpoints.
- All search sizes have been increased to 60 entries (3x the previous amount) to cover up a fatal sorting bug (that is, sorts are incongruent across pages).
- Pagination now works for genre pages
- Pagination behaves as expected for trending page (that is, setting `p` for standard trending returns `{"results": []}`

# How?
- Genre-filtered call to TMDB's Discovery endpoint
- 1 MM page = 3 (configurable) TMDB pages

# Why?
Result of discussions at weekly team meeting. This *mitigates* concerns raised.

# Testing
- Pytest
- Black
- Manual testing

# Completely Unrelated Known Bugs
- The CW upvote/downvote tests no longer works because it deleted itself due to low trust. Lol, oops. We need to fix that. (https://github.com/ContentWarnings/Backend/issues/71)