### PR TITLE
Fix MR Dictionary Bug

### DIFF
--- a/src/movies/MovieReduced.py
+++ b/src/movies/MovieReduced.py
@@ -68,7 +68,7 @@ class MovieReduced(BaseModel):
         UNKNOWN = "Unknown"
 
         def get_val(key: str) -> str:
-            val = json_map[key]
+            val = json_map.get(key, None)
             return UNKNOWN if (val is None or val == "") else val
 
         def get_mpa(id: int) -> str:


### PR DESCRIPTION
# What?
Fixed bug with `MovieReduced` object creation (querying python dict/hash map with absent key results in exception).

# How?
Safely query python dict by returning None if the key doesn't exist.

# Testing
I couldn't repro URL/query Jeffrey mentioned b/c the movies obtained from TMDB change based on the day (trending movies), but relevant pytests work and the change should fix it.