### PR TITLE
Fix Spaces w/Poster URLs

### DIFF
--- a/src/movies/get_unknown_genre_poster.py
+++ b/src/movies/get_unknown_genre_poster.py
@@ -17,6 +17,9 @@ def get_unknown_poster_url(genres: List[str]):
     if len(genres) > 0:
         genre = genres[0]
 
+    # encode spaces for hitting the image URL endpoint
+    genre = genre.replace(" ", "%20")
+
     return f"https://api.moviementor.app/genre_poster/{genre}"
 
 


### PR DESCRIPTION
# What?
Fixes #79 by encoding spaces with "%20" in obtaining unknown poster images.

# Testing
manual & pytest