### PR TITLE
Fix email header stylings

### DIFF
--- a/src/email/Emailer.py
+++ b/src/email/Emailer.py
@@ -94,7 +94,7 @@ class Emailer:
             color: #ffffff;
             height: 50px;
             display: inline-block;
-            width: fit-content;
+            width: auto;
             border: none;
         }}
     </style>


### PR DESCRIPTION
# What?
- Fixed this monstrosity if you are using non-Chromium engines (WebKit, Gecko):
![image](https://user-images.githubusercontent.com/43482496/226813305-96cafd55-ec25-444e-95a3-e141101e284c.png)


# How?
- `s/fit-contents/auto` in `Emailer.py`. It's a CSS tweak.

# Testing
- I used Inspect Element in the Gmail web app once I reproduced the bug.
![image](https://user-images.githubusercontent.com/43482496/226813450-58ae274e-e986-41f1-aa81-ac8f2587feb8.png)


# Links
- I need to get better at testing in other engines. I used to be better at this I swear! >_<