### PR TITLE
Fix Deploy Pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ sendgrid==6.9.7
 six==1.16.0
 sniffio==1.3.0
 starkbank-ecdsa==2.2.0
-starlette==0.25.0
+starlette==0.20.4
 tomli==2.0.1
 typing_extensions==4.4.0
 urllib3==1.26.12


### PR DESCRIPTION
# What?
Deploy pipeline broke due to dependabot latest changes. Not sure why but reverting for now.